### PR TITLE
Add function to generate openapi spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,87 @@ def my_route():
     return MyModel(...)
 ```
 
+### OpenAPI Specs
+
+To add OpenAPI 3.0 specification, please follow these examples:
+
+#### Only add `query` or `body` in document.
+
+```python
+# necessary imports
+
+app = Flask(__name___)
+
+@app.route("/post", methods=["POST"])
+@openapi_docs()
+@validate()
+def post(body: BodyModel, query: QueryModel):
+    return ResponseModel(
+        ...
+    )
+
+...
+
+# to register `/docs/` to the `app`
+add_openapi_spec(app)
+
+```
+
+#### Add `response`, `exceptions` and `tags` in document
+
+```python
+# necessary imports
+
+app = Flask(__name___)
+
+from flask_pydantic.openapi import APIError
+
+access_denied = APIError(code=403, msg="Access Denied")
+
+@app.route("/post", methods=["POST"])
+@openapi_docs(response=ResponseModel, tags=["demo"], exceptions=[access_denied])
+@validate()
+def post(body: BodyModel, query: QueryModel):
+    return ResponseModel(
+        id=id_,
+        age=query.age,
+        name=body.name,
+        nickname=body.nickname,
+    )
+...
+
+# to register `/docs/` to the `app`
+add_openapi_spec(app)
+```
+
+#### Add Auth Security Schemes
+
+```python
+# necessary imports, app and model definition
+# add routes on app or blueprint
+app.register_blueprint(some_blueprint)
+...
+
+# register openapi docs blueprint to `app`
+add_openapi_spec(
+    app,
+    extra_props={
+        "components": {
+            "securitySchemes": {
+                "bearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer",
+                    "bearerFormat": "JWT",
+                    "in": "header",
+                }
+            }
+        },
+        "security": [{"bearerAuth": []}]
+    },
+)
+
+```
+
 ### Example app
 
 For more complete examples see [example application](https://github.com/bauerji/flask_pydantic/tree/master/example_app).

--- a/example_app/app.py
+++ b/example_app/app.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
+from flask_pydantic.openapi import APIError
 from typing import Optional
 
 from flask import Flask, jsonify, request
-from flask_pydantic import validate
+from flask_pydantic import validate, add_openapi_spec, openapi_docs
 from pydantic import BaseModel
 
 app = Flask("flask_pydantic_app")
@@ -42,6 +43,7 @@ class ResponseModel(BaseModel):
 
 
 @app.route("/", methods=["POST"])
+@openapi_docs(response=ResponseModel)
 @validate(body=BodyModel, query=QueryModel)
 def post():
     """
@@ -76,6 +78,7 @@ def post():
 
 
 @app.route("/kwargs", methods=["POST"])
+@openapi_docs(response=ResponseModel, tags=["kwargs"])
 @validate()
 def post_kwargs(body: BodyModel, query: QueryModel):
     """
@@ -102,6 +105,7 @@ def post_kwargs(form: FormModel, query: QueryModel):
 
 
 @app.route("/many", methods=["GET"])
+@openapi_docs(exceptions=[APIError(code=403, msg="Access Denied")])
 @validate(response_many=True)
 def get_many():
     """
@@ -126,3 +130,6 @@ def select_from_array():
         return BodyModel(**request.body_params[request.query_params.index].dict())
     except IndexError:
         return jsonify({"reason": "index out of bound"}), 400
+
+
+add_openapi_spec(app)

--- a/example_app/example.py
+++ b/example_app/example.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from flask import Flask
 from flask_pydantic import validate
-from pydantic import BaseModel
+from pydantic import BaseModel, add_openapi_spec, openapi_docs
 
 app = Flask("flask_pydantic_app")
 
@@ -16,12 +16,20 @@ class QueryModel(BaseModel):
     age: int
 
 
+class ResponseModel(BaseModel):
+    id: int
+    age: int
+    name: str
+    nickname: Optional[str]
+
+
 class FormModel(BaseModel):
     name: str
     nickname: Optional[str]
 
 
 @app.route("/", methods=["GET"])
+@openapi_docs(response=ResponseModel)
 @validate()
 def get(query: QueryModel):
     age = query.age
@@ -37,14 +45,8 @@ curl --location --request GET 'http://127.0.0.1:5000/?age=5'
 """
 
 
-class ResponseModel(BaseModel):
-    id: int
-    age: int
-    name: str
-    nickname: Optional[str]
-
-
 @app.route("/character/<character_id>/", methods=["GET"])
+@openapi_docs()
 @validate()
 def get_character(character_id: int):
     characters = [
@@ -66,6 +68,7 @@ curl http://127.0.0.1:5000/character/2/ \
 
 
 @app.route("/", methods=["POST"])
+@openapi_docs()
 @validate()
 def post(body: RequestBodyModel):
     name = body.name
@@ -110,6 +113,7 @@ curl --location --request POST 'http://127.0.0.1:5000/form' \
 
 
 @app.route("/both", methods=["POST"])
+@openapi_docs()
 @validate()
 def get_and_post(body: RequestBodyModel, query: QueryModel):
     name = body.name  # From request body
@@ -128,6 +132,7 @@ curl --location --request POST 'http://127.0.0.1:5000/both?age=40' \
 --data-raw '{"name":123}'
 """
 
+add_openapi_spec(app)
 
 if __name__ == "__main__":
     app.run()

--- a/flask_pydantic/__init__.py
+++ b/flask_pydantic/__init__.py
@@ -1,2 +1,3 @@
 from .core import validate  # noqa: F401
+from .openapi import add_openapi_spec, openapi_docs  # noqa F401
 from .version import __version__  # noqa: F401

--- a/flask_pydantic/core.py
+++ b/flask_pydantic/core.py
@@ -1,7 +1,8 @@
 from functools import wraps
 from typing import Any, Callable, Iterable, List, Optional, Tuple, Type, Union
 
-from flask import Response, current_app, jsonify, make_response, request
+from flask import current_app, jsonify, make_response, request
+from flask.wrappers import Response
 from pydantic import BaseModel, ValidationError
 from pydantic.tools import parse_obj_as
 
@@ -11,6 +12,8 @@ from .exceptions import (
     JsonBodyParsingError,
     ManyModelValidationError,
 )
+
+from .openapi import OpenAPI, APIError
 
 try:
     from flask_restful import original_flask_make_response as make_response
@@ -288,6 +291,9 @@ def validate(
 
             return res
 
+        # register this decorator's args
+        setattr(wrapper, "_body", body)
+        setattr(wrapper, "_query", query)
         return wrapper
 
     return decorate

--- a/flask_pydantic/openapi.py
+++ b/flask_pydantic/openapi.py
@@ -1,0 +1,464 @@
+import re
+import inspect
+from functools import wraps
+from typing import Any, Callable, Iterable, List, Optional, Tuple, Type, Union
+
+from flask import Flask, Blueprint, render_template, jsonify, abort
+from flask.views import MethodView
+from werkzeug.routing import parse_converter_args
+from pydantic import BaseModel
+
+OPENAPI_VERSION = "3.0.2"
+OPENAPI_INFO = dict(
+    title="Service Documents",
+    version="latest",
+)
+
+OPENAPI_NAME = "docs"
+OPENAPI_ENDPOINT = "/docs/"
+OPENAPI_URL_PREFIX = None
+OPENAPI_MODE = "normal"
+
+OPENAPI_TEMPLATE_FOLDER = "templates"
+OPENAPI_FILENAME = "openapi.json"
+OPENAPI_UI = "swagger"
+
+
+RE_PARSE_RULE = re.compile(
+    r"""
+    (?P<static>[^<]*)                           # static rule data
+    <
+    (?:
+        (?P<converter>[a-zA-Z_][a-zA-Z0-9_]*)   # converter name
+        (?:\((?P<args>.*?)\))?                  # converter arguments
+        \:                                      # variable delimiter
+    )?
+    (?P<variable>[a-zA-Z_][a-zA-Z0-9_]*)        # variable name
+    >
+    """,
+    re.VERBOSE,
+)
+
+
+def parse_rule(rule):
+    """
+    Parse a rule and return it as generator. Each iteration yields tuples in the form
+    ``(converter, arguments, variable)``. If the converter is `None` it's a static url part, otherwise it's a dynamic
+    one.
+    Note: This originally lived in werkzeug.routing.parse_rule until it was removed in werkzeug 2.2.0.
+    """
+    pos = 0
+    end = len(rule)
+    do_match = RE_PARSE_RULE.match
+    used_names = set()
+    while pos < end:
+        m = do_match(rule, pos)
+        if m is None:
+            break
+        data = m.groupdict()
+        if data["static"]:
+            yield None, None, data["static"]
+        variable = data["variable"]
+        converter = data["converter"] or "default"
+        if variable in used_names:
+            raise ValueError(f"variable name {variable!r} used twice.")
+        used_names.add(variable)
+        yield converter, data["args"] or None, variable
+        pos = m.end()
+    if pos < end:
+        remaining = rule[pos:]
+        if ">" in remaining or "<" in remaining:
+            raise ValueError(f"malformed url rule: {rule!r}")
+        yield None, None, remaining
+
+
+def add_openapi_spec(
+    app: Flask,
+    endpoint: str = OPENAPI_ENDPOINT,
+    url_prefix: Optional[str] = OPENAPI_URL_PREFIX,
+    template_folder: str = OPENAPI_TEMPLATE_FOLDER,
+    openapi_filename: str = OPENAPI_FILENAME,
+    mode: str = OPENAPI_MODE,
+    ui: str = OPENAPI_UI,
+    openapi_version: str = OPENAPI_VERSION,
+    openapi_info: dict = OPENAPI_INFO,
+    extra_props: dict = {},
+):
+    assert isinstance(app, Flask)
+    assert mode in {"normal", "greedy", "strict"}
+
+    if not hasattr(add_openapi_spec, "openapi"):
+        add_openapi_spec.openapi = OpenAPI(
+            app,
+            endpoint=endpoint,
+            url_prefix=url_prefix,
+            mode=mode,
+            openapi_version=openapi_version,
+            openapi_info=openapi_info,
+            extra_props=extra_props,
+        )
+    openapi = add_openapi_spec.openapi
+    openapi.extra_props = extra_props
+
+    name = OPENAPI_NAME
+    blueprint = Blueprint(
+        name, __name__, url_prefix=url_prefix, template_folder=template_folder
+    )
+    blueprint.add_url_rule(
+        endpoint,
+        name,
+        view_func=APIView().as_view(
+            name, view_args=dict(ui=ui, filename=openapi_filename)
+        ),
+    )
+
+    # docs/openapi.json
+    @blueprint.route(f"{endpoint}<filename>")
+    def ___jsonfile___(filename):
+        if openapi_filename == filename:
+            return jsonify(openapi.spec)
+        abort(404)
+
+    app.register_blueprint(blueprint)
+
+
+class APIView(MethodView):
+    def __init__(self, *args, **kwargs):
+        view_args = kwargs.pop("view_args", {})
+        self.ui = view_args.get("ui")
+        self.filename = view_args.get("filename")
+        super().__init__(*args, **kwargs)
+
+    def get(self):
+        assert self.ui in {"redoc", "swagger"}
+        ui_file = f"{self.ui}.html"
+        return render_template(ui_file, spec_url=self.filename)
+
+
+class APIError:
+    def __init__(self, code: int, msg: str) -> None:
+        self.code = code
+        self.msg = msg
+
+    def __repr__(self) -> str:
+        return f"{self.code} {self.msg}"
+
+
+class OpenAPI:
+    _models = {}
+
+    def __init__(
+        self,
+        app: Flask,
+        endpoint: str = OPENAPI_ENDPOINT,
+        url_prefix: Optional[str] = OPENAPI_URL_PREFIX,
+        mode: str = OPENAPI_MODE,
+        openapi_version: str = OPENAPI_VERSION,
+        openapi_info: dict = OPENAPI_INFO,
+        extra_props: dict = {},
+    ) -> None:
+        assert isinstance(app, Flask)
+
+        self.app = app
+        self.endpoint: str = endpoint
+        self.url_prefix: Optional[str] = url_prefix
+        self.mode: str = mode
+        self.openapi_version: str = openapi_version
+        self.info: dict = openapi_info
+        self.extra_props: dict = extra_props
+
+        self._spec = None
+
+    @property
+    def spec(self):
+        if self._spec is None:
+            self._spec = self.generate_spec()
+        return self._spec
+
+    def _bypass(self, func) -> bool:
+        if self.mode == "greedy":
+            return False
+        elif self.mode == "strict":
+            if getattr(func, "_openapi", None) == self.__class__:
+                return False
+            return True
+        else:
+            decorator = getattr(func, "_openapi", None)
+            if decorator and decorator != self.__class__:
+                return True
+            return False
+
+    def generate_spec(self):
+        """
+        generate OpenAPI spec JSON file
+        """
+
+        routes = {}
+        tags = {}
+
+        for rule in self.app.url_map.iter_rules():
+            if str(rule).startswith(
+                (f"{self.url_prefix or ''}{self.endpoint}", "/static")
+            ):
+                continue
+
+            func = self.app.view_functions[rule.endpoint]
+            path, parameters = parse_url(str(rule))
+
+            # bypass the function decorated by others
+            if self._bypass(func):
+                continue
+
+            # multiple methods (with different func) may bond to the same path
+            if path not in routes:
+                routes[path] = {}
+
+            for method in rule.methods:
+                if method in ["HEAD", "OPTIONS"]:
+                    continue
+
+                if hasattr(func, "tags"):
+                    for tag in func.tags:
+                        if tag not in tags:
+                            tags[tag] = {"name": tag}
+
+                summary, desc = get_summary_desc(func)
+                spec = {
+                    "summary": summary or func.__name__.capitalize(),
+                    "description": desc or "",
+                    "operationID": func.__name__ + "__" + method.lower(),
+                    "tags": getattr(func, "tags", []),
+                }
+
+                if hasattr(func, "body"):
+                    spec["requestBody"] = {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": f"#/components/schemas/{func.body}"}
+                            }
+                        }
+                    }
+
+                params = parameters[:]
+                if hasattr(func, "query"):
+                    params.append(
+                        {
+                            "name": func.query,
+                            "in": "query",
+                            "required": True,
+                            "schema": {
+                                "$ref": f"#/components/schemas/{func.query}",
+                            },
+                        }
+                    )
+                spec["parameters"] = params
+
+                spec["responses"] = {}
+                has_2xx = False
+                if hasattr(func, "exceptions"):
+                    for code, msg in func.exceptions.items():
+                        if code.startswith("2"):
+                            has_2xx = True
+                        spec["responses"][code] = {
+                            "description": msg,
+                        }
+
+                if hasattr(func, "response"):
+                    spec["responses"]["200"] = {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": f"#/components/schemas/{func.response}"
+                                }
+                            }
+                        },
+                    }
+                elif not has_2xx:
+                    spec["responses"]["200"] = {"description": "Successful Response"}
+
+                if any(
+                    [hasattr(func, schema) for schema in ("query", "body", "response")]
+                ):
+                    spec["responses"]["400"] = {
+                        "description": "Validation Error",
+                    }
+
+                routes[path][method.lower()] = spec
+
+        definitions = {}
+        for _, schema in self._models.items():
+            if "definitions" in schema:
+                for key, value in schema["definitions"].items():
+                    definitions[key] = value
+                del schema["definitions"]
+
+        data = {
+            "openapi": self.openapi_version,
+            "info": self.info,
+            "tags": list(tags.values()),
+            "paths": {**routes},
+            "components": {
+                "schemas": {name: schema for name, schema in self._models.items()},
+            },
+            "definitions": definitions,
+        }
+
+        merge_dicts(data, self.extra_props)
+
+        return data
+
+    @classmethod
+    def add_model(cls, model):
+        cls._models[model.__name__] = model.schema()
+
+
+def get_summary_desc(func):
+    """
+    get summary, description from `func.__doc__`
+
+    Summary and description are split by '\n\n'. If only one is provided,
+    it will be used as summary.
+    """
+    doc = inspect.getdoc(func)
+    if not doc:
+        return None, None
+    doc = doc.split("\n\n", 1)
+    if len(doc) == 1:
+        return doc[0], None
+    return doc
+
+
+def get_converter_schema(converter: str, *args, **kwargs):
+    """
+    get json schema for parameters in url based on following converters
+    https://werkzeug.palletsprojects.com/en/0.15.x/routing/#builtin-converter
+    """
+    if converter == "any":
+        return {"type": "array", "items": {"type": "string", "enum": args}}
+    elif converter == "int":
+        return {
+            "type": "integer",
+            "format": "int32",
+            **{
+                f"{prop}imum": kwargs[prop] for prop in ["min", "max"] if prop in kwargs
+            },
+        }
+    elif converter == "float":
+        return {"type": "number", "format": "float"}
+    elif converter == "uuid":
+        return {"type": "string", "format": "uuid"}
+    elif converter == "path":
+        return {"type": "string", "format": "path"}
+    elif converter == "string":
+        return {
+            "type": "string",
+            **{
+                prop: kwargs[prop]
+                for prop in ["length", "maxLength", "minLength"]
+                if prop in kwargs
+            },
+        }
+    else:
+        return {"type": "string"}
+
+
+def parse_url(path: str):
+    """
+    Parsing Flask route url to get the normal url path and parameter type.
+
+    Based on Werkzeug_ builtin converters.
+
+    .. _werkzeug: https://werkzeug.palletsprojects.com/en/0.15.x/routing/#builtin-converters
+    """
+    subs = []
+    parameters = []
+
+    for converter, arguments, variable in parse_rule(path):
+        if converter is None:
+            subs.append(variable)
+            continue
+        subs.append(f"{{{variable}}}")
+
+        args, kwargs = [], {}
+
+        if arguments:
+            args, kwargs = parse_converter_args(arguments)
+
+        schema = get_converter_schema(converter, *args, **kwargs)
+
+        parameters.append(
+            {
+                "name": variable,
+                "in": "path",
+                "required": True,
+                "schema": schema,
+            }
+        )
+
+    return "".join(subs), parameters
+
+
+def merge_dicts(d1, d2):
+    """
+    Merge dictionary `d2` into `d1` and return the `d1`.
+
+    If `d2` has nested dictionaries which also exists in `d1`, the nested dictionaries
+    will be merged recursively instead of replacing them.
+
+    For example:
+    merge_dicts({"c": {"a":1}}, {"c":{"b":2}}) => {"c":{"a": 1, "b": 2}}
+
+    """
+    for k, v in d1.items():
+        if k in d2:
+            v2 = d2.pop(k)
+            if isinstance(v, dict):
+                if isinstance(v2, dict):
+                    merge_dicts(v, v2)
+                else:
+                    d1[k] = v2
+            else:
+                d1[k] = v2
+    d1.update(d2)
+    return d1
+
+def openapi_docs(
+    response: Optional[Type[BaseModel]] = None,
+    exceptions: List[APIError] = [],
+    tags: List[str] = [],
+):
+    def decorate(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            res = func(*args, **kwargs)
+            return res
+
+        query = func.__annotations__.get("query") or getattr(func, "_query", None)
+        body = func.__annotations__.get("body") or getattr(func, "_body", None)
+
+        # register schemas to this function
+        for model, name in zip((query, body, response), ("query", "body", "response")):
+            if model:
+                assert issubclass(model, BaseModel)
+                OpenAPI.add_model(model)
+                setattr(wrapper, name, model.__name__)
+
+        # register exceptions
+        api_errs = {}
+        for e in exceptions:
+            assert isinstance(e, APIError)
+            api_errs[str(e.code)] = e.msg
+        if api_errs:
+            setattr(wrapper, "exceptions", api_errs)
+
+        # register tags
+        if tags:
+            setattr(wrapper, "tags", tags)
+
+        # register OpenAPI class
+        setattr(wrapper, "_openapi", OpenAPI)
+
+        return wrapper
+
+    return decorate

--- a/flask_pydantic/templates/redoc.html
+++ b/flask_pydantic/templates/redoc.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>ReDoc</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+</head>
+
+<body>
+    <redoc spec-url='{{ spec_url }}'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js" integrity="sha384-6NTob50j5nI0a6UI+90MrMeRELliuH6W2xdFhyf2iP7oSZtveZF590YuEN6j3CsX" crossorigin="anonymous"> </script>
+</body>
+
+</html>

--- a/flask_pydantic/templates/swagger.html
+++ b/flask_pydantic/templates/swagger.html
@@ -1,0 +1,58 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Swagger UI</title>
+        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css" >
+        <style>
+        html
+        {
+            box-sizing: border-box;
+            overflow: -moz-scrollbars-vertical;
+            overflow-y: scroll;
+        }
+
+        *,
+        *:before,
+        *:after
+        {
+            box-sizing: inherit;
+        }
+
+        body
+        {
+            margin:0;
+            background: #fafafa;
+        }
+        </style>
+    </head>
+
+    <body>
+        <div id="swagger-ui"></div>
+
+        <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-bundle.js" integrity="sha384-FmneyJkRPHFkuDW0lbKmxyH/E04/ZDXVEQ34pZsXn7tmUqKAW2JvNsv+ffhwFCv3" crossorigin="anonymous"> </script>
+        <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-standalone-preset.js" integrity="sha384-+PppK9yWbWLTPGMUWborQ2V1Xk0Gk2ugovL3eiL0sjp7IHWzTaZ0OsKERwpQHLUn" crossorigin="anonymous"> </script>
+        <script>
+        window.onload = function() {
+        // Begin Swagger UI call region
+        const ui = SwaggerUIBundle({
+            url: "{{ spec_url }}",
+            dom_id: '#swagger-ui',
+            deepLinking: true,
+            presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIStandalonePreset
+            ],
+            plugins: [
+            SwaggerUIBundle.plugins.DownloadUrl
+            ],
+            layout: "StandaloneLayout"
+        })
+        // End Swagger UI call region
+
+        window.ui = ui
+        }
+    </script>
+    </body>
+</html>

--- a/setup.py
+++ b/setup.py
@@ -61,4 +61,5 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    zip_safe=False,
 )

--- a/tests/unit/test_parse_url.py
+++ b/tests/unit/test_parse_url.py
@@ -1,0 +1,163 @@
+import pytest
+
+from flask_pydantic.openapi import parse_url
+
+TEST_PARAM_NAME = "test_param"
+EXPECTED_PATH = "/{%s}" % TEST_PARAM_NAME
+
+PARSE_URL_PARAMETRIZE = [
+    (
+        f'/<any(test1, test2, test3, test4, "test,test"):{TEST_PARAM_NAME}>',
+        (
+            EXPECTED_PATH,
+            [
+                {
+                    "name": "test_param",
+                    "in": "path",
+                    "required": True,
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": (("test1", "test2", "test3", "test4", "test,test")),
+                        },
+                    },
+                }
+            ],
+        ),
+    ),
+    (
+        f"/<int:{TEST_PARAM_NAME}>",
+        (
+            EXPECTED_PATH,
+            [
+                {
+                    "name": "test_param",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "integer", "format": "int32"},
+                }
+            ],
+        ),
+    ),
+    (
+        f"/<int(max=2):{TEST_PARAM_NAME}>",
+        (
+            EXPECTED_PATH,
+            [
+                {
+                    "name": "test_param",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "integer", "maximum": 2, "format": "int32"},
+                }
+            ],
+        ),
+    ),
+    (
+        f"/<int(min=2):{TEST_PARAM_NAME}>",
+        (
+            EXPECTED_PATH,
+            [
+                {
+                    "name": "test_param",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "integer", "minimum": 2, "format": "int32"},
+                }
+            ],
+        ),
+    ),
+    (
+        f"/<float:{TEST_PARAM_NAME}>",
+        (
+            EXPECTED_PATH,
+            [
+                {
+                    "name": "test_param",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "number", "format": "float"},
+                }
+            ],
+        ),
+    ),
+    (
+        f"/<uuid:{TEST_PARAM_NAME}>",
+        (
+            EXPECTED_PATH,
+            [
+                {
+                    "name": "test_param",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string", "format": "uuid"},
+                }
+            ],
+        ),
+    ),
+    (
+        f"/<path:{TEST_PARAM_NAME}>",
+        (
+            EXPECTED_PATH,
+            [
+                {
+                    "name": "test_param",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string", "format": "path"},
+                }
+            ],
+        ),
+    ),
+    (
+        f"/<string:{TEST_PARAM_NAME}>",
+        (
+            EXPECTED_PATH,
+            [
+                {
+                    "name": "test_param",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            ],
+        ),
+    ),
+    (
+        f"/<string(length=2):{TEST_PARAM_NAME}>",
+        (
+            EXPECTED_PATH,
+            [
+                {
+                    "name": "test_param",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"length": 2, "type": "string"},
+                }
+            ],
+        ),
+    ),
+    (
+        f"/<default:{TEST_PARAM_NAME}>",
+        (
+            EXPECTED_PATH,
+            [
+                {
+                    "name": "test_param",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            ],
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("path, expected_data", PARSE_URL_PARAMETRIZE)
+def test_parse_url(path, expected_data):
+    result_path, result_params = parse_url(path)
+    expected_path, expected_params = expected_data
+    assert result_path == expected_path
+    assert result_params == expected_params


### PR DESCRIPTION
Built off of @buildpeak's forked PR #41. Added `parse_url` method to mimic what `werkzeug`'s did. This was copied from [flask-restx](https://github.com/python-restx/flask-restx)'s [PR #463](https://github.com/python-restx/flask-restx/pull/463).