### PR TITLE
remove pytest-black plug as its no longer maintained to keep CI green

### DIFF
--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -4,5 +4,4 @@ pytest
 pytest-flask
 pytest-flake8
 pytest-coverage
-pytest-black
 pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 testpaths = tests
-addopts = -vv --black --cov --cov-config=setup.cfg  -s
+addopts = -vv --cov --cov-config=setup.cfg  -s
 flake8-ignore = E121 E122 E123 E124 E125 E126 E127 E128 E711 E712 F811 F841 H803 E501 E265 E741 W391 W503 E203
 
 [coverage:run]


### PR DESCRIPTION
remove pytest-black plug as its no longer maintained, and casuing error with our CI for python version 3.8 and above, #87 