### PR TITLE
fix: added _is_sequence() to support more sequence types in models and tests for new cases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macOS-latest]
         # Python 3.7 is not supported on Apple ARM64,
         # or the latest Ubuntu 2404

--- a/flask_pydantic/converters.py
+++ b/flask_pydantic/converters.py
@@ -1,4 +1,6 @@
-from typing import Type, Union
+import types
+from collections import deque
+from typing import Deque, FrozenSet, List, Sequence, Set, Tuple, Type, Union
 
 try:
     from typing import get_args, get_origin
@@ -10,15 +12,29 @@ from pydantic.v1 import BaseModel as V1BaseModel
 from werkzeug.datastructures import ImmutableMultiDict
 
 V1OrV2BaseModel = Union[BaseModel, V1BaseModel]
+UnionType = getattr(types, "UnionType", Union)
+
+sequence_types = {
+    Sequence,
+    List,
+    list,
+    Tuple,
+    tuple,
+    Set,
+    set,
+    FrozenSet,
+    frozenset,
+    Deque,
+    deque,
+}
 
 
-def _is_list(type_: Type) -> bool:
-    origin = get_origin(type_)
-    if origin is list:
-        return True
-    if origin is Union:
-        return any(_is_list(t) for t in get_args(type_))
-    return False
+def _is_sequence(type_: Type) -> bool:
+    origin = get_origin(type_) or type_
+    if origin is Union or origin is UnionType:
+        return any(_is_sequence(t) for t in get_args(type_))
+
+    return origin in sequence_types and origin not in (str, bytes)
 
 
 def convert_query_params(
@@ -38,7 +54,7 @@ def convert_query_params(
                 key: value
                 for key, value in query_params.to_dict(flat=False).items()
                 if key in model.model_fields
-                and _is_list(model.model_fields[key].annotation)
+                and _is_sequence(model.model_fields[key].annotation)
             },
         }
     else:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -59,19 +59,21 @@ class FormModel(BaseModel):
 
 
 class RequestBodyWithIterableModel(BaseModel):
-    b1: List[str]
-    b2: Tuple[str, int]
-    b3: Optional[List[int]] = None
-    b4: Union[Tuple[str, int], None] = None
+    b1: List
+    b2: List[str]
+    b3: Tuple[str, int]
+    b4: Optional[List[int]] = None
+    b5: Union[Tuple[str, int], None] = None
 
 
 if sys.version_info >= (3, 10):
     # New Python(>=3.10) syntax tests
     class RequestBodyWithIterableModelPy310(BaseModel):
-        b1: list[str]
-        b2: tuple[str, int]
-        b3: list[int] | None = None
-        b4: tuple[str, int] | None = None
+        b1: list
+        b2: list[str]
+        b3: tuple[str, int]
+        b4: list[int] | None = None
+        b5: tuple[str, int] | None = None
 
 
 class RequestBodyModelRoot(RootModel):
@@ -220,21 +222,23 @@ validate_test_cases = [
         ValidateParams(
             body_model=RequestBodyWithIterableModel,
             request_body={
-                "b1": ["str1", "str1"],
-                "b2": ("str", 123),
-                "b3": [1, 2, 3],
-                "b4": ("str", 321),
+                "b1": ["str1", "str2"],
+                "b2": ["str1", "str2"],
+                "b3": ("str", 123),
+                "b4": [1, 2, 3],
+                "b5": ("str", 321),
             },
             expected_response_body={
-                "b1": ["str1", "str1"],
-                "b2": ("str", 123),
-                "b3": [1, 2, 3],
-                "b4": ("str", 321),
+                "b1": ["str1", "str2"],
+                "b2": ["str1", "str2"],
+                "b3": ("str", 123),
+                "b4": [1, 2, 3],
+                "b5": ("str", 321),
             },
             response_model=RequestBodyWithIterableModel,
             expected_status_code=200,
         ),
-        id="ASASD",
+        id="iterable and Optional[Iterable] fields in pydantic model",
     ),
 ]
 
@@ -245,21 +249,23 @@ if sys.version_info >= (3, 10):
                 ValidateParams(
                     body_model=RequestBodyWithIterableModelPy310,
                     request_body={
-                        "b1": ["str1", "str1"],
-                        "b2": ("str", 123),
-                        "b3": [1, 2, 3],
-                        "b4": ("str", 321),
+                        "b1": ["str1", "str2"],
+                        "b2": ["str1", "str2"],
+                        "b3": ("str", 123),
+                        "b4": [1, 2, 3],
+                        "b5": ("str", 321),
                     },
                     expected_response_body={
-                        "b1": ["str1", "str1"],
-                        "b2": ("str", 123),
-                        "b3": [1, 2, 3],
-                        "b4": ("str", 321),
+                        "b1": ["str1", "str2"],
+                        "b2": ["str1", "str2"],
+                        "b3": ("str", 123),
+                        "b4": [1, 2, 3],
+                        "b5": ("str", 321),
                     },
                     response_model=RequestBodyWithIterableModelPy310,
                     expected_status_code=200,
                 ),
-                id="ASASD",
+                id="iterable and Iterable | None fields in pydantic model (Python 3.10+)",
             ),
         ]
     )

--- a/tests/util.py
+++ b/tests/util.py
@@ -21,7 +21,7 @@ def assert_matches(expected: ExpectedType, actual: ActualType):
         assert set(expected.keys()) == set(actual.keys())
         for key, value in expected.items():
             assert_matches(value, actual[key])
-    elif isinstance(expected, list):
+    elif isinstance(expected, (list, tuple)):
         assert len(expected) == len(actual)
         for a, b in zip(expected, actual):
             assert_matches(a, b)


### PR DESCRIPTION
Fixing issue https://github.com/pallets-eco/flask-pydantic/issues/104
Made something similar to fastapi `field_annotation_is_sequence` checks
https://github.com/fastapi/fastapi/blob/7c75b555804388e885d991497942be777fa8af3a/fastapi/_compat.py#L546
