### PR TITLE
Support async views. Fixes #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,10 @@ Feature requests and pull requests are welcome. For major changes, please open a
   python3 -m venv venv
   source venv/bin/activate
   ```
+- install runtime dependencies
+  ```bash
+  python3 -m pip install -e .
+  ```
 - install development requirements
   ```bash
   python3 -m pip install -r requirements/test.txt

--- a/flask_pydantic/core.py
+++ b/flask_pydantic/core.py
@@ -282,7 +282,7 @@ def validate(
                     return make_response(
                         jsonify({"validation_error": err}), status_code
                     )
-            res = func(*args, **kwargs)
+            res = current_app.ensure_sync(func)(*args, **kwargs)
 
             if response_many:
                 if is_iterable_of_models(res):

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,3 +3,4 @@ pytest-flask
 pytest-coverage
 pytest-mock
 pytest-ruff
+Flask[async]


### PR DESCRIPTION
Resolve #91 by following guidance from [Flask docs](https://flask.palletsprojects.com/en/latest/async-await/#extensions).
This was initially done inside a [bigger PR](https://github.com/pallets-eco/flask-pydantic/pull/70) by @MarekPikula [here](https://github.com/pallets-eco/flask-pydantic/commit/f6c2afc96dd43b36cc86cd594221eef84aafacfe#diff-2d15eea3c71c90e84e8fc64a4f33dda8278da008a4aafb2a910bde786b27a285R293)  however that branch is very much out of date with HEAD.